### PR TITLE
Changed help exit code to zero

### DIFF
--- a/CopraRNA2.pl
+++ b/CopraRNA2.pl
@@ -244,7 +244,7 @@ print "\nCopraRNA 2.0.6\n\n",
 "2. Wright PR et al., CopraRNA and IntaRNA: predicting small RNA targets, networks and interaction domains\n   Nucleic Acids Research, 2014, 42 (W1), W119-W123\n",
 "\n";
 
-exit(-1);
+exit(0);
 
 }
 


### PR DESCRIPTION
Bioconda recipe check requires sucess exit code, change the exit code invoking --help accordingly.